### PR TITLE
fix: guard release tarball rename against same-file mv

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,11 @@ jobs:
           VERSION: ${{ steps.version.outputs.next }}
         run: |
           pnpm pack # respects files:[dist]; produces expost-<package.json version>.tgz
-          mv expost-*.tgz "expost-${VERSION#v}.tgz"
+          src=$(ls expost-*.tgz)
+          dest="expost-${VERSION#v}.tgz"
+          # Align the asset name with the release tag. Skip when pack already
+          # named it right (package.json version == tag) — mv onto itself errors.
+          [ "$src" = "$dest" ] || mv "$src" "$dest"
       - name: Create release with tarball
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What

Guard the `mv` in the release workflow's pack step so it doesn't try to move the tarball onto itself.

## Why it failed

Third time's the charm. The [last run](https://github.com/bsoule/expost/actions/runs/29417525177/job/87359311142) got all the way through semver-bootstrap, install, build, and pack — then died on:

```
mv: 'expost-1.0.0.tgz' and 'expost-1.0.0.tgz' are the same file
```

`pnpm pack` names the tarball from `package.json`'s version (`1.0.0`), and the release tag resolved to `v1.0.0`, so the rename-to-tag `mv` had identical source and dest → error → no release.

## Fix

Only rename when the packed name and the tag-derived name actually differ (they diverge once tags advance past the static `package.json` version):

```sh
src=$(ls expost-*.tgz)
dest="expost-${VERSION#v}.tgz"
[ "$src" = "$dest" ] || mv "$src" "$dest"
```

Verified both branches locally (same-name → skip; `1.0.0` pack + `v1.1.0` tag → renames to `expost-1.1.0.tgz`).

## Result

Merging cuts **`v1.0.0`** with `expost-1.0.0.tgz` attached (every prior step already passed on the last run), unblocking beeminder/blog#762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)